### PR TITLE
Updated linear-converter to version 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "floating-adapter": "1.2.0",
-    "linear-converter": "3.1.0"
+    "linear-converter": "7.0.0"
   }
 }


### PR DESCRIPTION
:rocket:

linear-converter just published version 7.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 43 commits (ahead by 43, behind by 0).
- [4f8b27a](https://github.com/javiercejudo/linear-converter/commit/4f8b27aa7fade79a16ad58ac88c6c07a01ea43fc): 7.0.0
- [c2f9705](https://github.com/javiercejudo/linear-converter/commit/c2f97059c6783b4f454d2771e885fce76372b0f6): Merge pull request #22 from javiercejudo/api-changes
- [b9e7745](https://github.com/javiercejudo/linear-converter/commit/b9e77450b64a32d599a69d01beb8e9407746f51e): feat(api): rename api methods to replace preset with conversion
- [6009910](https://github.com/javiercejudo/linear-converter/commit/6009910159ff1e5fe2242a40ec0d29f2b16dc896): 6.0.4
- [82b8aeb](https://github.com/javiercejudo/linear-converter/commit/82b8aeb030ad64bd3808f68d408b8dd3c6b752bb): docs(README): update examples to not use linear-presets
- [6804f2f](https://github.com/javiercejudo/linear-converter/commit/6804f2ff921fb51be81d49b7d97c912c7aa2fb96): test: fix browser test
- [e3b2cac](https://github.com/javiercejudo/linear-converter/commit/e3b2cac005743082ba67bfbea6f51c22f949d1e8): test(browsers): run test on Microsoft Edge
- [5769d26](https://github.com/javiercejudo/linear-converter/commit/5769d260604a60e052f830c3e33d91f5df023cce): 6.0.3
- [5fc46dd](https://github.com/javiercejudo/linear-converter/commit/5fc46ddb570666961e998069061a3ff5606ed821): chore(package): add version script
- [766f253](https://github.com/javiercejudo/linear-converter/commit/766f253d6adc9936c193ef5e2e5e83fcf344010c): 6.0.2
- [76a5afe](https://github.com/javiercejudo/linear-converter/commit/76a5afe8669ad65b68b5a7110eb10656083aee17): chore(deps): update linear-presets to version 2.0.0
- [a2504fc](https://github.com/javiercejudo/linear-converter/commit/a2504fc8ffe09358209adb0c79dec8e87c3e086c): Merge pull request #20 from javiercejudo/greenkeeper-gulp-sourcemaps-1.6.0
- [0141ec0](https://github.com/javiercejudo/linear-converter/commit/0141ec09a642215c6025f03b97b5abf7fc558b8a): chore(package): updated gulp-sourcemaps to version 1.6.0
- [0248a21](https://github.com/javiercejudo/linear-converter/commit/0248a21a448ce6d3005483216441e93714cbfbab): fix(build): test on real browsers if npm ver is 4
- [294ef53](https://github.com/javiercejudo/linear-converter/commit/294ef5334a21ddb82b90dbe8934cda41d18d5035): Merge pull request #19 from javiercejudo/greenkeeper-pin

There are 43 commits in total. See the [full diff](https://github.com/javiercejudo/linear-converter/compare/74092ad4f6bfe778c777bae2ceed38573135fd21...4f8b27aa7fade79a16ad58ac88c6c07a01ea43fc).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
